### PR TITLE
APP-5375 Fix variable/label issue for environment banner in prod and re-enable prod deployment stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,13 +104,13 @@ stages:
         environment: 'PreProd'
         azureSubscription: 'AppServicesDevOps-NonProd'
 
-# - stage: DeployProd
-#   displayName: 'Deploy to Prod'
-#   condition: and(succeeded(), contains(variables['build.sourceBranch'], 'refs/heads/release/'))
-#   variables:
-#     - group: FIP-Prod
-#   jobs:
-#     - template: deploy-jobs-template.yml
-#       parameters:
-#         environment: 'Prod'
-#        azureSubscription: 'AppServicesDevOps-Prod'
+- stage: DeployProd
+  displayName: 'Deploy to Prod'
+  condition: and(succeeded(), contains(variables['build.sourceBranch'], 'refs/heads/release/'))
+  variables:
+    - group: FIP-Prod
+  jobs:
+    - template: deploy-jobs-template.yml
+      parameters:
+        environment: 'Prod'
+        azureSubscription: 'AppServicesDevOps-Prod'

--- a/deploy-jobs-template.yml
+++ b/deploy-jobs-template.yml
@@ -47,7 +47,7 @@ jobs:
               package: '$(Pipeline.Workspace)/**/${{ parameters.appZipFile }}'
               appSettings: >
                 -PhaseBanner "$(phaseBanner)"
-                -EnvironmentBanner "${{ parameters.environment }}" 
+                -EnvironmentBanner "$(EnvironmentBanner)"
                 -EnvironmentBannerText "$(EnvironmentBannerText)"
                 -FipApiConnectorClientOptions__BaseAddress "$(FipApiConnectorClientOptions__BaseAddress)"
           - task: AzureAppServiceManage@0


### PR DESCRIPTION
PR Contains following fixes:

- Due to code requiring Prod environment banner to be lower case 'p', feeding environment banner value as a variable from variable group rather than relying on environment map (that will cause the Prod value to be 'Prod' rather than 'prod').
- Re-enabled the prod deployment stage that had been commented out and after checking with the team, there is no known reason for this to be the case (might have perhaps been that the infra didn't exist/didn't want to deploy to Prod at the point in time the pipeline was created).
