### PR TITLE
Feature/app 6925 remove fax from auth body

### DIFF
--- a/INSS.FIP.Functions/INSS.FIP.Functions.csproj
+++ b/INSS.FIP.Functions/INSS.FIP.Functions.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="1.5.1" />

--- a/INSS.FIP.Functions/Program.cs
+++ b/INSS.FIP.Functions/Program.cs
@@ -5,11 +5,16 @@ using INSS.FIP.Functions.Helper;
 using INSS.FIP.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Azure.Functions.Worker;
+
 
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
     .ConfigureServices(services =>
     {
+        services.AddApplicationInsightsTelemetryWorkerService();
+        services.ConfigureFunctionsApplicationInsights();
+
         services.AddHttpClient();
         services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 

--- a/INSS.FIP.Models/DomainModels/AuthBodyDomainModel.cs
+++ b/INSS.FIP.Models/DomainModels/AuthBodyDomainModel.cs
@@ -14,6 +14,5 @@ public class AuthBodyDomainModel
     public string AuthBodyAddressLine5 { get; set; } = null!;
     public string AuthBodyPostcode { get; set; } = null!;
     public string AuthBodyPhone { get; set; } = null!;
-    public string AuthBodyFaxNo { get; set; } = null!;
     public string AuthBodyWebsite { get; set; } = null!;
 }

--- a/INSS.FIP.Models/ResponseModels/FipApiAuthBodyResponseModel.cs
+++ b/INSS.FIP.Models/ResponseModels/FipApiAuthBodyResponseModel.cs
@@ -13,7 +13,6 @@ public class FipApiAuthBodyResponseModel
     public string AuthBodyAddressLine4 { get; set; } = null!;
     public string AuthBodyAddressLine5 { get; set; } = null!;
     public string AuthBodyPostcode { get; set; } = null!;
-    public string AuthBodyPhone { get; set; } = null!;
-    public string AuthBodyFaxNo { get; set; } = null!;
+    public string AuthBodyPhone { get; set; } = null!;   
     public string AuthBodyWebsite { get; set; } = null!;
 }

--- a/INSS.FIP.Web/AutoMapperProfiles/DomainModelToViewModelProfiles.cs
+++ b/INSS.FIP.Web/AutoMapperProfiles/DomainModelToViewModelProfiles.cs
@@ -18,7 +18,6 @@ public class DomainModelToViewModelProfiles : Profile
             .ForMember(d => d.Name, opt => opt.MapFrom(s => s.AuthBodyName))
             .ForMember(d => d.Address, opt => opt.MapFrom(s => string.Join(", ", $"{s.AuthBodyAddressLine1}|{s.AuthBodyAddressLine2}|{s.AuthBodyAddressLine3}|{s.AuthBodyAddressLine4}|{s.AuthBodyAddressLine5}|{s.AuthBodyPostcode}".Split('|', StringSplitOptions.RemoveEmptyEntries))))
             .ForMember(d => d.Telephone, opt => opt.MapFrom(s => s.AuthBodyPhone))
-            .ForMember(d => d.Fax, opt => opt.MapFrom(s => s.AuthBodyFaxNo))
             .ForMember(d => d.Website, opt => opt.MapFrom(s => s.AuthBodyWebsite));
 
         CreateMap<SearchResultDomainModel, SearchResultViewModel>()

--- a/INSS.FIP.Web/ViewModels/AuthBodyViewModel.cs
+++ b/INSS.FIP.Web/ViewModels/AuthBodyViewModel.cs
@@ -25,7 +25,5 @@ public class AuthBodyViewModel
 
     public string Telephone { get; set; } = null!;
 
-    public string Fax { get; set; } = null!;
-
     public string Website { get; set; } = null!;
 }

--- a/INSS.FIP.Web/Views/AuthBody/Index.cshtml
+++ b/INSS.FIP.Web/Views/AuthBody/Index.cshtml
@@ -51,14 +51,6 @@
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            @Html.DisplayNameFor(model => model.AuthBodies!.First().Fax)
-                        </dt>
-                        <dd class="govuk-summary-list__value">
-                            @Html.DisplayFor(model => authBody.Fax)
-                        </dd>
-                    </div>
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">
                             @Html.DisplayNameFor(model => model.AuthBodies!.First().Website)
                         </dt>
                         <dd class="govuk-summary-list__value">

--- a/INSS.FIP.Web/Views/IP/Details.cshtml
+++ b/INSS.FIP.Web/Views/IP/Details.cshtml
@@ -139,14 +139,6 @@
                     <p class="govuk-body">@Model.AuthBody.Telephone</p>
                 </dd>
             </div>
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                    Fax number
-                </dt>
-                <dd class="govuk-summary-list__value">
-                    <p class="govuk-body">@Model.AuthBody.Fax</p>
-                </dd>
-            </div>
         </dl>
         }
         <a class="govuk-button" style="text-decoration:none;" asp-controller="Ip" asp-action="Search">


### PR DESCRIPTION
Removal of fax number from auth body - have stopped short of database we don't want to be rooting around in there.  It is legacy and will need to be retired at the earliest opportunity.

We will need to consider Fax number for IPs separately - first getting business approval - shouldn't be too difficult.

For IPs, fax number is currently displayed if:
- legacy feed is used, not supported in INSSight feed
- it is populated, which it is for a third of 1500 records
- a quick check of a few populated cases, none display fax numbers on their website