### PR TITLE
APP-6925 DB script to remove fax from dbo.findipauthbody

### DIFF
--- a/INSS.FIP.Data/DatabaseScripts/REL-xxx Remove Fax from dbo.findipauthbody.sql
+++ b/INSS.FIP.Data/DatabaseScripts/REL-xxx Remove Fax from dbo.findipauthbody.sql
@@ -1,0 +1,20 @@
+--Apply script
+
+IF EXISTS (SELECT 1 FROM sys.columns 
+        WHERE Name = N'fax' AND 
+        Object_ID=Object_ID(N'dbo.findipauthbody'))
+BEGIN
+	ALTER TABLE [dbo].[findipauthbody] DROP COLUMN [fax]
+END
+GO
+
+
+----Rollback script - Uncomment following section to apply
+
+--IF NOT EXISTS (SELECT 1 FROM sys.columns 
+--        WHERE Name = N'fax' AND 
+--        Object_ID=Object_ID(N'dbo.findipauthbody'))
+--BEGIN
+--    ALTER TABLE [dbo].[findipauthbody] ADD [fax] int NULL
+--END
+--GO

--- a/INSS.FIP.Data/INSS.FIP.Data.csproj
+++ b/INSS.FIP.Data/INSS.FIP.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -10,5 +10,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="DatabaseScripts\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Other DB objects left as is on purpose:

**dbo.ci_ip_authorising_body**
This is legacy, likely impacted by ISCIS synchronisation scripts we do not want to be digging into that

**synw-edw-pre-uks-001.sql.azuresynapse.net > SilverLayer > Views > ext.vw_findipauthbody**
These are INSSight controlled - for FCMC team to remove