### PR TITLE
Feature/app 6286 sync cmp bkt creditors to ods

### DIFF
--- a/INSS.FIP.Data/CMPDataSource/BankruptcyCreditorsRepository.cs
+++ b/INSS.FIP.Data/CMPDataSource/BankruptcyCreditorsRepository.cs
@@ -1,0 +1,55 @@
+﻿using INSS.FIP.Data.CMPDataSource.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace INSS.FIP.Data.CMPDataSource
+{
+    public class BankruptcyCreditorsRepository : IBankruptcyCreditorsRepository
+    {
+        private readonly targetCMPDbContext _context;
+        private IDbContextTransaction? _transaction;
+
+        public BankruptcyCreditorsRepository(targetCMPDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task AddBankruptcyCreditorsListAsync(List<BankruptcyCreditorsList> records)
+        {
+            await _context.BankruptcyCreditorsLists.AddRangeAsync(records);
+        }
+
+        public async Task BeginTransactionAsync()
+        {
+            _transaction = await _context.Database.BeginTransactionAsync();
+        }
+
+        public async Task CommitTransactionAsync()
+        {
+            if (_transaction == null)
+            {
+                throw new CMPSyncDatabaseException("No transaction in progress to commit.");
+            }
+            await _transaction.CommitAsync(); ;
+        }
+
+        public async Task DeleteAllBankruptcyCreditorsListAsync()
+        {
+            await _context.BankruptcyCreditorsLists.ExecuteDeleteAsync();
+        }
+
+        public async Task RollbackTransactionAsync()
+        {
+            if (_transaction == null)
+            {
+                throw new CMPSyncDatabaseException("No transaction in progress to rollback.");
+            }
+            await _transaction.RollbackAsync();
+        }
+
+        public async Task SaveBankruptcyCreditorsListChangesAsync()
+        {
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/INSS.FIP.Data/CMPDataSource/Interfaces/IBankruptcyCreditorsRepository.cs
+++ b/INSS.FIP.Data/CMPDataSource/Interfaces/IBankruptcyCreditorsRepository.cs
@@ -1,0 +1,20 @@
+﻿
+
+namespace INSS.FIP.Data.CMPDataSource.Interfaces
+{
+    ///<summary>Implementation of Repository pattern for for unit tests as mocking EF Core is a b@t%h.</summary>
+    public interface IBankruptcyCreditorsRepository
+    {
+        Task AddBankruptcyCreditorsListAsync(List<BankruptcyCreditorsList> records);
+
+        Task DeleteAllBankruptcyCreditorsListAsync();
+
+        Task SaveBankruptcyCreditorsListChangesAsync();
+
+        Task BeginTransactionAsync();
+
+        Task CommitTransactionAsync();
+
+        Task RollbackTransactionAsync();
+    }
+}

--- a/INSS.FIP.Data/CMPDataSource/sourceCMPDbContextExtension.cs
+++ b/INSS.FIP.Data/CMPDataSource/sourceCMPDbContextExtension.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace INSS.FIP.Data.CMPDataSource
+{
+    public static class sourceCMPDbContextExtension
+    {
+        public static string GetViewNameWithSchema<T>(this sourceCMPDbContext context) where T : class
+        {
+            var entityType = context.Model.FindEntityType(typeof(T));
+            var qualifiedViewName = entityType?.GetSchemaQualifiedViewName();
+            return qualifiedViewName ?? "Unknown (Check configured values for CMPDataViewNameSchema and CMPDataViewName)";
+        }
+    }
+}

--- a/INSS.FIP.DataAccess/BankruptcyCreditorsProvider.cs
+++ b/INSS.FIP.DataAccess/BankruptcyCreditorsProvider.cs
@@ -1,8 +1,9 @@
 ﻿using AutoMapper;
 using INSS.FIP.Data;
 using INSS.FIP.Data.CMPDataSource;
+using INSS.FIP.Data.CMPDataSource.Interfaces;
 using INSS.FIP.Data.FCMCDataSource;
-using INSS.FIP.Interfaces;
+using INSS.FIP.Interfaces.CMP;
 using INSS.FIP.Models.CentrallyManagedPartyModels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -11,13 +12,13 @@ namespace INSS.FIP.DataAccess;
 
 public class BankruptcyCreditorsProvider : IDataTargetProvider<CentrallyManagedPartyModel>
 {
-    private readonly targetCMPDbContext _targetCMPDbContext; 
+    private readonly IBankruptcyCreditorsRepository _bankruptcyCreditorsRepo; 
     private readonly ILogger<BankruptcyCreditorsProvider> _logger;
     private readonly IMapper _mapper;
 
-    public BankruptcyCreditorsProvider(targetCMPDbContext targetCMPDbContext, ILogger<BankruptcyCreditorsProvider> logger, IMapper mapper)
+    public BankruptcyCreditorsProvider(IBankruptcyCreditorsRepository bankruptcyCreditorsRepo, ILogger<BankruptcyCreditorsProvider> logger, IMapper mapper)
     {
-        _targetCMPDbContext = targetCMPDbContext;
+        _bankruptcyCreditorsRepo = bankruptcyCreditorsRepo;
         _logger = logger;
         _mapper = mapper;
     }
@@ -34,19 +35,19 @@ public class BankruptcyCreditorsProvider : IDataTargetProvider<CentrallyManagedP
             mappedData[i].Id = i + 1;
         }
 
-        using var transaction = await _targetCMPDbContext.Database.BeginTransactionAsync();
+        await _bankruptcyCreditorsRepo.BeginTransactionAsync();
 
         try
         {
-            await _targetCMPDbContext.BankruptcyCreditorsLists.ExecuteDeleteAsync();
-            await _targetCMPDbContext.BankruptcyCreditorsLists.AddRangeAsync(mappedData);
+            await _bankruptcyCreditorsRepo.DeleteAllBankruptcyCreditorsListAsync();
+            await _bankruptcyCreditorsRepo.AddBankruptcyCreditorsListAsync(mappedData);
 
-            await _targetCMPDbContext.SaveChangesAsync();
-            await transaction.CommitAsync();
+            await _bankruptcyCreditorsRepo.SaveBankruptcyCreditorsListChangesAsync();
+            await _bankruptcyCreditorsRepo.CommitTransactionAsync();
         }
         catch (Exception ex)
         {
-            await transaction.RollbackAsync();
+            await _bankruptcyCreditorsRepo.RollbackTransactionAsync();
             throw new CMPSyncDatabaseException("Error saving data to BankruptcyCreditorsList table",ex) ;
         }
     }

--- a/INSS.FIP.DataAccess/CMPDataSourceProvider.cs
+++ b/INSS.FIP.DataAccess/CMPDataSourceProvider.cs
@@ -1,11 +1,11 @@
 ﻿using INSS.FIP.Data.CMPDataSource;
-using INSS.FIP.Interfaces;
 using INSS.FIP.Models.CentrallyManagedPartyModels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Data.SqlClient;
 
 using System.Collections.Generic;
+using INSS.FIP.Interfaces.CMP;
 
 
 namespace INSS.FIP.DataAccess;

--- a/INSS.FIP.DataAccess/CMPDataSourceProvider.cs
+++ b/INSS.FIP.DataAccess/CMPDataSourceProvider.cs
@@ -3,6 +3,10 @@ using INSS.FIP.Interfaces;
 using INSS.FIP.Models.CentrallyManagedPartyModels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Data.SqlClient;
+
+using System.Collections.Generic;
+
 
 namespace INSS.FIP.DataAccess;
 
@@ -19,19 +23,37 @@ public class CMPDataSourceProvider : IDataSourceProvider<CentrallyManagedPartyMo
 
     public async Task<List<CentrallyManagedPartyModel>> GetDataFromViewAsync()
     {
-        var result = await _sourceDbContext.viewData.AsNoTracking()
-            .Select(x => new CentrallyManagedPartyModel
-            {
-                SourceRef = x.SourceRef,
-                Name = x.Name,
-                AddressLine1 = x.AddressLine1,
-                AddressLine2 = x.AddressLine2,
-                AddressLine3 = x.AddressLine3,
-                Town = x.Town,
-                County = x.County,
-                PostCode = x.PostCode,
-                Country = x.Country
-            }).ToListAsync();
+
+        List<VwOdsInssightcmp> records = null;
+
+        //Following block will throw a custom exception if configured view doesn't have all properties required by VwOdsInssightcmp.
+        //Difficult to unit test due to lack of key and configurable nature of view, tested on actual database.
+        try
+        {
+            records = await _sourceDbContext.viewData.AsNoTracking().ToListAsync();
+        }
+        catch (SqlException ex)
+        {
+            throw new CMPSyncDatabaseException($"Error retrieving data from configured source: {_sourceDbContext.GetViewNameWithSchema<VwOdsInssightcmp>()}" +
+                $" as schema does not match agreed standard. Following issues detected: {ex.Message}", ex);
+        }
+
+        List<CentrallyManagedPartyModel> result = null;
+
+        result = records.Select(x => new CentrallyManagedPartyModel()
+        {
+            SourceRef = x.SourceRef,
+            Name = x.Name,
+            AddressLine1 = x.AddressLine1,
+            AddressLine2 = x.AddressLine2,
+            AddressLine3 = x.AddressLine3,
+            Town = x.Town,
+            County = x.County,
+            PostCode = x.PostCode,
+            Country = x.Country
+        }).ToList();
+
         return result;
+
     }
 }

--- a/INSS.FIP.Functions.UnitTests/FunctionsTests/CMPSyncTests/BankruptcyCreditorsDataSourceProviderTests.cs
+++ b/INSS.FIP.Functions.UnitTests/FunctionsTests/CMPSyncTests/BankruptcyCreditorsDataSourceProviderTests.cs
@@ -1,0 +1,146 @@
+﻿
+using AutoMapper;
+using INSS.FIP.Data.CMPDataSource;
+using INSS.FIP.Data.CMPDataSource.Interfaces;
+using INSS.FIP.DataAccess;
+using INSS.FIP.DataAccess.Mappers;
+using INSS.FIP.Models.CentrallyManagedPartyModels;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Moq;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace INSS.FIP.Functions.UnitTests.FunctionsTests.CMPSyncTests
+{
+    
+    public class BankruptcyCreditorsDataSourceProviderTests
+    {
+        private IMapper _mapper;
+
+        [Fact]  
+        public async Task CentrallyManagedPartyTransformationTests()
+        {
+
+            //Arrange
+            var repoMock = new Mock<IBankruptcyCreditorsRepository>();
+            var logger = new Mock<ILogger<BankruptcyCreditorsProvider>>();
+
+            List<BankruptcyCreditorsList> args = null;
+            repoMock.Setup(c => c.AddBankruptcyCreditorsListAsync(It.IsAny<List<BankruptcyCreditorsList>>()))
+                    .Callback<List<BankruptcyCreditorsList>>((bcl) => args = bcl);
+
+            var entitiesToAdd = new List<BankruptcyCreditorsList> {new BankruptcyCreditorsList { Id = 1 },
+                                new BankruptcyCreditorsList { Id = 2 }};
+
+
+            MapperConfiguration mapperConfig = new(
+                cfg =>
+                {
+                    cfg.AddProfile(new CMPMapper());
+
+                });
+
+            _mapper = new Mapper(mapperConfig);
+
+            var aProvider = new BankruptcyCreditorsProvider(repoMock.Object, logger.Object, _mapper);
+
+            //Act
+            await aProvider.TruncateAndInsertAsync(new List<CentrallyManagedPartyModel> 
+            {
+                new CentrallyManagedPartyModel (),
+                new CentrallyManagedPartyModel ()
+            });
+
+            //Assert 
+            Assert.Equal(entitiesToAdd, args, new BankruptcyCreditorsListListComparer());
+        }
+
+
+
+        private class BankruptcyCreditorsListListComparer : IEqualityComparer<List<BankruptcyCreditorsList>>
+        {
+
+            public bool Equals(List<BankruptcyCreditorsList>? x, List<BankruptcyCreditorsList>? y)
+            {
+                if (x == null && y == null)
+                {
+                    return true;
+                }
+
+                if (x == null || y == null)
+                {
+                    return false;
+                }
+
+                if (x.Count != y.Count)
+                {
+                    return false;
+                }
+
+                var bclComparer = new BankruptcyCreditorsListComparer();
+
+                for (int i = 0; i < x.Count; i++)
+                {
+                    if (!bclComparer.Equals(x[i], y[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+
+            }
+
+            public int GetHashCode([DisallowNull] List<BankruptcyCreditorsList> obj)
+            {
+                int value = 0;
+
+                for (int i = 0; i < obj.Count; i++)
+                {
+                    value = value + (int)Math.Pow(2, i);
+                }
+
+                return value;
+            }
+        }
+
+
+
+        private class BankruptcyCreditorsListComparer : IEqualityComparer<BankruptcyCreditorsList>
+        {
+
+            public bool Equals(BankruptcyCreditorsList? x, BankruptcyCreditorsList? y)
+            {
+                if (x == null && y == null)
+                {
+                    return true;
+                }
+
+                if (x == null || y == null)
+                {
+                    return false;
+                }
+
+                var properties = typeof(BankruptcyCreditorsList).GetProperties();
+                foreach (var property in properties)
+                {
+                    if (property.GetValue(x)?.ToString() != property.GetValue(y)?.ToString())
+                    {
+                        return false;
+                    }
+                }
+
+                return true; 
+            }
+
+            public int GetHashCode([DisallowNull] BankruptcyCreditorsList obj)
+            {
+                return obj.ToString().ToLower().GetHashCode();
+            }
+
+        }
+    }
+}

--- a/INSS.FIP.Functions.UnitTests/Helpers/DbSyncCMPDataTests.cs
+++ b/INSS.FIP.Functions.UnitTests/Helpers/DbSyncCMPDataTests.cs
@@ -2,7 +2,7 @@
 using FakeItEasy;
 using INSS.FIP.Data.CMPDataSource;
 using INSS.FIP.Functions.Helper;
-using INSS.FIP.Interfaces;
+using INSS.FIP.Interfaces.CMP;
 using INSS.FIP.Models.CentrallyManagedPartyModels;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/INSS.FIP.Functions.UnitTests/Helpers/DbSyncCMPDataTests.cs
+++ b/INSS.FIP.Functions.UnitTests/Helpers/DbSyncCMPDataTests.cs
@@ -44,7 +44,7 @@ public class DbSyncCMPDataTests
         A.CallTo(() => _fakeTargetRepository.TruncateAndInsertAsync(A<List<CentrallyManagedPartyModel>>._)).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _dbSyncCMPData.SynchronizeBankruptcyCreditorsAsync();
+        var result = await _dbSyncCMPData.SynchronizeDataAsync();
 
         // Assert
         Assert.True(result, ConstantValues.SynchronizationSuccessfulMessage);
@@ -66,7 +66,7 @@ public class DbSyncCMPDataTests
         A.CallTo(() => _fakeTargetRepository.TruncateAndInsertAsync(A<List<CentrallyManagedPartyModel>>._)).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _dbSyncCMPData.SynchronizeBankruptcyCreditorsAsync();
+        var result = await _dbSyncCMPData.SynchronizeDataAsync();
 
         // Assert
         Assert.True(result, "Synchronization return true with empty data");

--- a/INSS.FIP.Functions.UnitTests/INSS.FIP.Functions.UnitTests.csproj
+++ b/INSS.FIP.Functions.UnitTests/INSS.FIP.Functions.UnitTests.csproj
@@ -8,7 +8,9 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -21,8 +23,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INSS.FIP.Functions\INSS.FIP.Functions.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="FunctionsTests\CMPSyncTests\" />
   </ItemGroup>
 </Project>

--- a/INSS.FIP.Functions.UnitTests/INSS.FIP.Functions.UnitTests.csproj
+++ b/INSS.FIP.Functions.UnitTests/INSS.FIP.Functions.UnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
@@ -20,5 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INSS.FIP.Functions\INSS.FIP.Functions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="FunctionsTests\CMPSyncTests\" />
   </ItemGroup>
 </Project>

--- a/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncHttpTrigger.cs
+++ b/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncHttpTrigger.cs
@@ -31,6 +31,6 @@ public class CMPSyncHttpTrigger
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required for HttpTrigger signature")]
     public async Task Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "CMPSyncHttp")] HttpRequest req)
     {
-        await _dbSyncCMPData.SynchronizeBankruptcyCreditorsAsync();
+        await _dbSyncCMPData.SynchronizeDataAsync();
     }
 }

--- a/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncHttpTrigger.cs
+++ b/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncHttpTrigger.cs
@@ -1,5 +1,4 @@
 ﻿using INSS.FIP.Data;
-using INSS.FIP.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
@@ -8,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using System.Net.Mime;
 using System.Net;
 using INSS.FIP.Models.CentrallyManagedPartyModels;
+using INSS.FIP.Interfaces.CMP;
 
 namespace INSS.FIP.Functions.Functions.CentrallyManagedParty;
 

--- a/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncTimerTrigger.cs
+++ b/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncTimerTrigger.cs
@@ -30,6 +30,6 @@ public class CMPSyncTimerTrigger
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required for HttpTrigger signature")]
     public async Task Run([TimerTrigger("%BankruptcyCreditorsSyncSchedulePattern%")] TimerInfo myTimer)
     {
-        await _dbSyncCMPData.SynchronizeBankruptcyCreditorsAsync();
+        await _dbSyncCMPData.SynchronizeDataAsync();
     }
 }

--- a/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncTimerTrigger.cs
+++ b/INSS.FIP.Functions/Functions/CentrallyManagedParty/CMPSyncTimerTrigger.cs
@@ -1,5 +1,4 @@
 ﻿using INSS.FIP.Data;
-using INSS.FIP.Interfaces;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
@@ -7,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using System.Net.Mime;
 using System.Net;
 using INSS.FIP.Models.CentrallyManagedPartyModels;
+using INSS.FIP.Interfaces.CMP;
 
 namespace INSS.FIP.Functions.Functions.CentrallyManagedParty;
 

--- a/INSS.FIP.Functions/Helper/DbSyncCMPData.cs
+++ b/INSS.FIP.Functions/Helper/DbSyncCMPData.cs
@@ -1,5 +1,5 @@
 ﻿using AutoMapper;
-using INSS.FIP.Interfaces;
+using INSS.FIP.Interfaces.CMP;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 

--- a/INSS.FIP.Functions/Helper/DbSyncCMPData.cs
+++ b/INSS.FIP.Functions/Helper/DbSyncCMPData.cs
@@ -18,7 +18,7 @@ public class DbSyncCMPData<TData> : IDbSyncData<TData>
         _logger = logger;
     }
 
-    public async Task<bool> SynchronizeBankruptcyCreditorsAsync()
+    public async Task<bool> SynchronizeDataAsync()
     {
         var sourceData = await _sourceProvider.GetDataFromViewAsync();
 

--- a/INSS.FIP.Functions/Program.cs
+++ b/INSS.FIP.Functions/Program.cs
@@ -1,9 +1,11 @@
 using INSS.FIP.Data;
 using INSS.FIP.Data.CMPDataSource;
+using INSS.FIP.Data.CMPDataSource.Interfaces;
 using INSS.FIP.Data.FCMCDataSource;
 using INSS.FIP.DataAccess;
 using INSS.FIP.Functions.Helper;
 using INSS.FIP.Interfaces;
+using INSS.FIP.Interfaces.CMP;
 using INSS.FIP.Models.CentrallyManagedPartyModels;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,11 +38,13 @@ var host = new HostBuilder()
             return new sourceCMPDbContext(connectionString, configuration);
         });
 
-        services.AddTransient<targetCMPDbContext>(sp =>
+        services.AddScoped<targetCMPDbContext>(sp =>
         {
             var connectionString = Environment.GetEnvironmentVariable("targetCMPDbContextConnectionString");
             return new targetCMPDbContext(connectionString);
         });
+
+        services.AddScoped<IBankruptcyCreditorsRepository, BankruptcyCreditorsRepository>();
 
         services.AddTransient<IAuthBodyProvider, AuthBodyProvider>();
         services.AddTransient<IInsolvencyPractitionerProvider, InsolvencyPractitionerProvider>();

--- a/INSS.FIP.Interfaces/CMP/IDataSourceProvider.cs
+++ b/INSS.FIP.Interfaces/CMP/IDataSourceProvider.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace INSS.FIP.Interfaces;
+namespace INSS.FIP.Interfaces.CMP;
 
-public interface IDbSyncData<TData>
+public interface IDataSourceProvider<T>
 {
-    Task<bool> SynchronizeDataAsync();
+    Task<List<T>> GetDataFromViewAsync();
 }

--- a/INSS.FIP.Interfaces/CMP/IDataTargetProvider.cs
+++ b/INSS.FIP.Interfaces/CMP/IDataTargetProvider.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace INSS.FIP.Interfaces;
+namespace INSS.FIP.Interfaces.CMP;
 
 public interface IDataTargetProvider<T>
 {

--- a/INSS.FIP.Interfaces/CMP/IDbSyncData.cs
+++ b/INSS.FIP.Interfaces/CMP/IDbSyncData.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace INSS.FIP.Interfaces;
+namespace INSS.FIP.Interfaces.CMP;
 
-public interface IDataSourceProvider<T>
+public interface IDbSyncData<TData>
 {
-    Task<List<T>> GetDataFromViewAsync();
+    Task<bool> SynchronizeDataAsync();
 }

--- a/INSS.FIP.Interfaces/IDbSyncData.cs
+++ b/INSS.FIP.Interfaces/IDbSyncData.cs
@@ -8,5 +8,5 @@ namespace INSS.FIP.Interfaces;
 
 public interface IDbSyncData<TData>
 {
-    Task<bool> SynchronizeBankruptcyCreditorsAsync();
+    Task<bool> SynchronizeDataAsync();
 }

--- a/INSS.FIP.Interfaces/INSS.FIP.Interfaces.csproj
+++ b/INSS.FIP.Interfaces/INSS.FIP.Interfaces.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Two main things here:

1. Code to check the configured view has the required fields.  They provider can't change things underneath us.
2. Refactor target to introduce Repository pattern to allow unit test.  In first instance I tried:

- Using InMemory Database - though that then required reaching into the database to pull out values for assert - not much fun, and In Memory databases not recommended where transactions are concerned - which we have
- Mocking entity framework core - managed to get an online example partially working - though example did not handle all latest feature of EF Core, needed to support current calls, to support believe would have need to upgrade to .Net 10, in end felt like was chasing unicorns so opted for Repository pattern based on online recommendation from a Microsoft bod